### PR TITLE
cmake: make project include-friendly

### DIFF
--- a/3rd_party/abseil.cmake
+++ b/3rd_party/abseil.cmake
@@ -1,4 +1,4 @@
-include(${PROJECT_SOURCE_DIR}/3rd_party/_conan.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/_conan.cmake)
 
 ################################################################################
 

--- a/3rd_party/glog.cmake
+++ b/3rd_party/glog.cmake
@@ -1,4 +1,4 @@
-include(${PROJECT_SOURCE_DIR}/3rd_party/_conan.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/_conan.cmake)
 
 ################################################################################
 

--- a/3rd_party/protobuf.cmake
+++ b/3rd_party/protobuf.cmake
@@ -1,4 +1,4 @@
-include(${PROJECT_SOURCE_DIR}/3rd_party/_conan.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/_conan.cmake)
 
 ################################################################################
 

--- a/3rd_party/tests/googletest.cmake
+++ b/3rd_party/tests/googletest.cmake
@@ -1,4 +1,4 @@
-include(${PROJECT_SOURCE_DIR}/3rd_party/_conan.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../_conan.cmake)
 
 ################################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,26 +11,26 @@ cmake_dependent_option(interstellar_lib_garble_HAS_CLIS "Build the various testi
 
 ################################################################################
 
-include(deps/cmake/compile_flags.cmake)
-include(deps/cmake/coverage.cmake)
-include(deps/cmake/options.cmake)
-include(deps/cmake/sanitizers.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/deps/cmake/compile_flags.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/deps/cmake/coverage.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/deps/cmake/options.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/deps/cmake/sanitizers.cmake)
 
 ################################################################################
 
-include(3rd_party/abseil.cmake)
-include(3rd_party/glog.cmake)
-include(3rd_party/protobuf.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/3rd_party/abseil.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/3rd_party/glog.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/3rd_party/protobuf.cmake)
 
-include(deps/protos.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/deps/protos.cmake)
 
 ################################################################################
 
 # the main sources
-add_subdirectory(data)
-add_subdirectory(src)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/data)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/src)
 
 if(interstellar_lib_garble_BUILD_TESTS)
   enable_testing()
-  add_subdirectory(tests)
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/tests)
 endif(interstellar_lib_garble_BUILD_TESTS)

--- a/deps/protos.cmake
+++ b/deps/protos.cmake
@@ -60,13 +60,13 @@ endfunction(compile_proto_cpp)
 
 ################################################################################
 
-compile_proto_cpp("./deps/protos/circuits/block.proto")
-compile_proto_cpp("./deps/protos/circuits/circuit.proto")
+compile_proto_cpp("${CMAKE_CURRENT_LIST_DIR}/protos/circuits/block.proto")
+compile_proto_cpp("${CMAKE_CURRENT_LIST_DIR}/protos/circuits/circuit.proto")
 # ideally we SHOULD split the proto in two distinct lib
 # .skcd for the input, .pgarbled for the output and both are separate folders in src/
-compile_proto_cpp("./deps/protos/skcd/skcd.proto")
-compile_proto_cpp("./deps/protos/circuits/prepackmsg.proto")
-compile_proto_cpp("./deps/protos/circuits/packmsg.proto")
+compile_proto_cpp("${CMAKE_CURRENT_LIST_DIR}/protos/skcd/skcd.proto")
+compile_proto_cpp("${CMAKE_CURRENT_LIST_DIR}/protos/circuits/prepackmsg.proto")
+compile_proto_cpp("${CMAKE_CURRENT_LIST_DIR}/protos/circuits/packmsg.proto")
 
 ################################################################################
 


### PR DESCRIPTION
Instead of add_directory-friendly

Needed to make deps using Conan play nice with our "export_all_target_libs"
(ie when used in project api_garble)