### PR TITLE
packmsg: take "digits" as param

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,7 +51,6 @@ target_link_libraries(packmsg_helper
     PRIVATE
     glog::glog
     absl::strings
-    absl::random_random
 
     packmsg
     garble_helper

--- a/src/packmsg_helper.h
+++ b/src/packmsg_helper.h
@@ -48,7 +48,7 @@ namespace interstellar::packmsg {
 void GarbleAndStrippedSkcdFromBuffer(std::string_view skcd_buffer,
                                      garble::ParallelGarbledCircuit *pgc,
                                      PrePackmsg *pre_packmsg,
-                                     std::vector<uint8_t> *digits);
+                                     const std::vector<uint8_t> &digits);
 
 Packmsg PackmsgFromPrepacket(const PrePackmsg &pre_packmsg,
                              const std::string &watermark_message);

--- a/tests/test_stripped.cpp
+++ b/tests/test_stripped.cpp
@@ -34,9 +34,9 @@ TEST(StrippedTest, DisplayOk) {
 
   garble::ParallelGarbledCircuit pgc;
   packmsg::PrePackmsg pre_packmsg;
-  std::vector<uint8_t> digits;
+  std::vector<uint8_t> digits{0, 1};
   packmsg::GarbleAndStrippedSkcdFromBuffer(skcd_buf, &pgc, &pre_packmsg,
-                                           &digits);
+                                           digits);
 
   auto prepackmsg_buf = packmsg::SerializePrepackmsg(pre_packmsg);
 
@@ -57,7 +57,7 @@ TEST(StrippedTest, GenericMustNotCrash) {
   std::vector<uint8_t> digits;
 
   EXPECT_THROW(packmsg::GarbleAndStrippedSkcdFromBuffer(skcd_buf, &pgc,
-                                                        &pre_packmsg, &digits),
+                                                        &pre_packmsg, digits),
                std::logic_error);
 
   EXPECT_EQ(pgc.nb_gates_, 9);
@@ -80,9 +80,9 @@ TEST(StrippedTest, PrePackmsgSerializationOk) {
 
   garble::ParallelGarbledCircuit pgc;
   packmsg::PrePackmsg pre_packmsg;
-  std::vector<uint8_t> digits;
+  std::vector<uint8_t> digits{0, 1};
   packmsg::GarbleAndStrippedSkcdFromBuffer(skcd_buf, &pgc, &pre_packmsg,
-                                           &digits);
+                                           digits);
 
   auto prepackmsg_buf = packmsg::SerializePrepackmsg(pre_packmsg);
   auto prepackmsg_copy =
@@ -101,9 +101,9 @@ TEST(StrippedTest, PackmsgSerializationOk) {
 
   garble::ParallelGarbledCircuit pgc;
   packmsg::PrePackmsg pre_packmsg;
-  std::vector<uint8_t> digits;
+  std::vector<uint8_t> digits{0, 1};
   packmsg::GarbleAndStrippedSkcdFromBuffer(skcd_buf, &pgc, &pre_packmsg,
-                                           &digits);
+                                           digits);
 
   packmsg::Packmsg packmsg =
       packmsg::PackmsgFromPrepacket(pre_packmsg, "test message");


### PR DESCRIPTION
Allow to get it from Rust instead of generating from C++ then giving it back to Rust to store